### PR TITLE
use webpack-dev-server, develop with hot reloads

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -20,7 +20,7 @@
           integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
           crossorigin="anonymous">
     <link rel="stylesheet"
-          href="build/omni-nav.bundle.css">
+          href="omni-nav.bundle.css">
   </head>
   <body>
     <div id="omni-nav-v2" class="pre-build" data-target="static"></div>
@@ -42,6 +42,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
             integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
             crossorigin="anonymous"></script>
-    <script src="build/omni-nav.bundle.js"></script>
+    <script src="omni-nav.bundle.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "**Omni-Nav** is a navigation bar that provides access to all content and services across our Chapman University websites. It offers universal **navigation** of our core services; it offers an in-page **search box** powered by Google; and it offers quick access to **log in** to other Chapman services.",
   "main": "index.js",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --optimize-minimize",
     "babel": "babel --presets es2015 js/index.js -o build/index.bundle.js",
-    "start": "http-server -p 5000",
+    "start": "webpack-dev-server",
     "test": "mocha --compilers js:babel-core/register ./test/test*.js"
   },
   "repository": {
@@ -26,14 +26,15 @@
     "babel-preset-es2015": "^6.24.1",
     "css-loader": "^0.28.4",
     "expect.js": "^0.3.1",
-    "extract-text-webpack-plugin": "^3.0.0",
-    "http-server": "^0.10.0",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "mocha": "^3.4.2",
     "mocha-sinon": "^2.0.0",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
     "sinon": "^2.3.7",
     "uglifyjs-webpack-plugin": "^0.4.6",
-    "webpack": "^3.1.0"
+    "webpack": "^4.1.0",
+    "webpack-cli": "^2.0.10",
+    "webpack-dev-server": "^3.1.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,10 +28,13 @@ module.exports = {
     new ExtractTextPlugin({ // define where to save the file
       filename: "[name]",
       allChunks: true,
-    }),
-    new webpack.optimize.UglifyJsPlugin({
-      include: /\.min\.js$/,
-      minimize: true
     })
-  ],
+	],
+	devServer: {
+		contentBase: __dirname + '/build',
+		compress: true,
+		port: 5000,
+		watchContentBase: true
+	},
+	mode: 'development',
 };


### PR DESCRIPTION
Hey there,

I see you are using webpack! Right on. I thought I’d chip in this change that allows you to get hot reloads, which I thought you might find useful during development.

Just `npm start` and have at it!

As you’ll see, not a lot changes in the code. We switch out `http-server` for `webpack-dev-server`, which means moving you on up to Webpack 4. Since you’re committing built files, webpack and webpack-dev-server really wanted to see `index.html` in that directory, I think so that keys in your wenpack entry matched up with link and script tags.

Anyway, I hope this helps, and feel free to hit me up if you have any questions.