### PR TITLE
Retire the Chapman Monogram icon logo

### DIFF
--- a/js/omni-nav.js
+++ b/js/omni-nav.js
@@ -20,9 +20,9 @@ var OmniNav = (function() {
     ["Overview", "https://www.chapman.edu/about/index.aspx", "icon-file-text"],
     ["Maps and Directions", "https://www.chapman.edu/about/maps-directions/index.aspx", "icon-location"],
     ["Visit Chapman", "https://www.chapman.edu/about/visit-chapman/index.aspx", "icon-california"],
-    ["Discover Chapman", "https://www.chapman.edu/discover/index.html", "icon-cu-monogram"],
+    ["Discover Chapman", "https://www.chapman.edu/discover/index.html", "icon-cu-window"],
     ["Our Campus", "https://www.chapman.edu/about/campus/index.aspx", "icon-office"],
-    ["Facts and History", "https://www.chapman.edu/about/facts-history/index.aspx", "icon-cu-monogram"],
+    ["Facts and History", "https://www.chapman.edu/about/facts-history/index.aspx", "icon-cu-window"],
     ["Administration", "https://www.chapman.edu/about/administration/index.aspx", "icon-cu-window"],
     ["Contact Us", "https://www.chapman.edu/about/contact-us.aspx", "icon-envelop"]
   ];
@@ -74,7 +74,7 @@ var OmniNav = (function() {
     ["Overview", "https://www.chapman.edu/support-chapman/index.aspx", "icon-file-text"],
     ["Contact Development", "https://www.chapman.edu/support-chapman/contact-us.aspx", "icon-envelop"],
     ["Get Involved", "https://www.chapman.edu/support-chapman/get-involved.aspx", "icon-hand"],
-    ["Areas to Support", "https://www.chapman.edu/support-chapman/ways-to-give/areas-to-support.aspx", "icon-cu-monogram"],
+    ["Areas to Support", "https://www.chapman.edu/support-chapman/ways-to-give/areas-to-support.aspx", "icon-cu-window"],
     ["Alumni", "https://www.chapman.edu/alumni/index.aspx", "icon-paw"]
   ];
 

--- a/js/omni-nav.js
+++ b/js/omni-nav.js
@@ -22,7 +22,7 @@ var OmniNav = (function() {
     ["Visit Chapman", "https://www.chapman.edu/about/visit-chapman/index.aspx", "icon-california"],
     ["Discover Chapman", "https://www.chapman.edu/discover/index.html", "icon-cu-window"],
     ["Our Campus", "https://www.chapman.edu/about/campus/index.aspx", "icon-office"],
-    ["Facts and History", "https://www.chapman.edu/about/facts-history/index.aspx", "icon-cu-window"],
+    ["Facts and History", "https://www.chapman.edu/about/facts-history/index.aspx", "icon-library4"],
     ["Administration", "https://www.chapman.edu/about/administration/index.aspx", "icon-cu-window"],
     ["Contact Us", "https://www.chapman.edu/about/contact-us.aspx", "icon-envelop"]
   ];


### PR DESCRIPTION
Story: https://trello.com/c/MFxQpdaA

Replaces old monogram with the Chapman window logo.